### PR TITLE
fix for skipping TLS verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Binary file of plugin is located at `build` directory
 
 Plugin contains follow configuration options:
 - `chef_server` - full url to your chef server e.g. https://chefserver/myorg
-- `check_tls` - Check certificate of chef server
+- `skip_tls` - Check certificate of chef server
 - `anyone_policies` - policies for apply to any clients
 - `ttl` - Duration after which authentication will expire
 - `max_ttl` - Maximum duration after which authentication will expire 

--- a/src/vault-auth-chef/chefclient/backend.go
+++ b/src/vault-auth-chef/chefclient/backend.go
@@ -97,7 +97,7 @@ information, team, behavior configuration tunables, and TTLs. For example:
 
     $ vault write auth/chef/config \
         chef_server="127.0.0.1" \
-        check_tls=false
+        skip_tls=false
 
 For more information and examples, please see the online documentation.
 
@@ -109,9 +109,9 @@ For more information and examples, please see the online documentation.
 						Description: "Slack OAuth access token for your Slack application.",
 					},
 
-					"check_tls": &framework.FieldSchema{
+					"skip_tls": &framework.FieldSchema{
 						Type:        framework.TypeBool,
-						Description: "Check certificate of chef server.",
+						Description: "Skip checking the certificate of chef server.",
 					},
 
 					"anyone_policies": &framework.FieldSchema{

--- a/src/vault-auth-chef/chefclient/config.go
+++ b/src/vault-auth-chef/chefclient/config.go
@@ -11,7 +11,7 @@ import (
 // config represents the internally stored configuration information.
 type config struct {
 	ChefServer string `json:"chef_server" structs:"chef_server"`
-	CheckTLS   bool   `json:"check_tls" structs:"check_tls"`
+	SkipTLS    bool   `json:"skip_tls" structs:"skip_tls"`
 	// AnyonePolicies is the list of policies to apply to any valid Chef clients.
 	AnyonePolicies []string `json:"anyone_policies" structs:"anyone_policies,omitempty"`
 

--- a/src/vault-auth-chef/chefclient/path_auth.go
+++ b/src/vault-auth-chef/chefclient/path_auth.go
@@ -129,6 +129,7 @@ func (b *backend) verifyCreds(ctx context.Context, req *logical.Request, client,
 		Name:    client,
 		Key:     key,
 		BaseURL: config.ChefServer,
+		SkipSSL: config.SkipTLS,
 	})
 
 	if err != nil {

--- a/src/vault-auth-chef/chefclient/path_config.go
+++ b/src/vault-auth-chef/chefclient/path_config.go
@@ -41,7 +41,7 @@ func (b *backend) pathConfigWrite(ctx context.Context, req *logical.Request, dat
 	}
 
 	// Get the tunable options
-	checkTLS := data.Get("check_tls").(bool)
+	skipTLS := data.Get("skip_tls").(bool)
 	anyonePolicies := data.Get("anyone_policies").([]string)
 
 	// Calculate TTLs, if supplied
@@ -51,7 +51,7 @@ func (b *backend) pathConfigWrite(ctx context.Context, req *logical.Request, dat
 	// Built the entry
 	entry, err := logical.StorageEntryJSON("config", &config{
 		ChefServer:     chefServer,
-		CheckTLS:       checkTLS,
+		SkipTLS:        skipTLS,
 		AnyonePolicies: anyonePolicies,
 		TTL:            ttl,
 		MaxTTL:         maxTTL,

--- a/src/vault-auth-chef/chefclient/path_info.go
+++ b/src/vault-auth-chef/chefclient/path_info.go
@@ -2,6 +2,7 @@ package chefclient
 
 import (
 	"context"
+
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/logical/framework"
 	"github.com/hashicorp/vault/version"


### PR DESCRIPTION
This small patch fixes broken option for disabling TLS verification. I also changed `check_tls` flag to `skip_tls` to be more intuitive.